### PR TITLE
Add port flag and testing config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test:
 	@$(MAKE) start_test_server || $(MAKE) kill_test_server
 
 start_test_server: stat
-	@bin/doic* & echo $$! > bin/.pid
+	@bin/doic* -port=8053 & echo $$! > bin/.pid
 	go test -v doic/*.go
 	@$(MAKE) kill_test_server
 

--- a/config.gcfg
+++ b/config.gcfg
@@ -1,6 +1,6 @@
 [doic]
 	loglevel	= "debug"
-	dnsport		= 8053
+	dnsport		= 53
 	upstreamdns	= "8.8.8.8:53"
 
 [redis]

--- a/deps/testing.config.gcfg
+++ b/deps/testing.config.gcfg
@@ -1,0 +1,8 @@
+[doic]
+	loglevel	= "debug"
+	dnsport		= 8053
+	upstreamdns	= "8.8.8.8:53"
+
+[redis]
+	host		= "localhost:6379"
+	password	= ""

--- a/doic/aname_resolve_test.go
+++ b/doic/aname_resolve_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestANameResolve(t *testing.T) {
 	// read in conf up a directory
-	readConf("../config.gcfg")
+	readConf("../deps/testing.config.gcfg")
 
 	m1 := new(dns.Msg)
 	m1.SetQuestion(dns.Fqdn("google.com"), dns.TypeA)

--- a/doic/doic.go
+++ b/doic/doic.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -28,6 +29,14 @@ var config = Config{}
 func main() {
 	readConf("config.gcfg")
 	initLogger(config.Doic.Loglevel)
+
+	// parse override flags
+	overrideDNSPort := flag.Int("port", config.Doic.DNSPort, "DNS port to bind to.")
+	flag.Parse()
+
+	if *overrideDNSPort != config.Doic.DNSPort {
+		config.Doic.DNSPort = *overrideDNSPort
+	}
 
 	// format the string to be :port
 	fPort := fmt.Sprint(":", config.Doic.DNSPort)


### PR DESCRIPTION
I have changed the default port to `53` and added an addition config file (for tests) at `deps/testing.config.gcfg`.  In the Makefile we start the test server with the flag `-port=8053` to bind the server on port 53 and then the test units read in the `deps/testing.config.gcfg` config to test on 8053.

This applies to https://github.com/mfaltys/doic/issues/1